### PR TITLE
loosen faraday version restriction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    omni_exchange (1.3.0)
-      faraday (= 0.17.4)
+    omni_exchange (1.4.0)
+      faraday (< 2)
       money (~> 6.13.1)
 
 GEM
@@ -12,17 +12,38 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
-    dotenv (2.7.6)
-    faraday (0.17.4)
-      multipart-post (>= 1.2, < 3)
-    i18n (1.10.0)
+    dotenv (2.8.1)
+    faraday (1.10.1)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     money (6.13.8)
       i18n (>= 0.6.4, <= 2)
     multipart-post (2.2.3)
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.1.2.1)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -53,14 +74,16 @@ GEM
       rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.18.0)
+    rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     unicode-display_width (1.8.0)
     vcr (6.1.0)
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   dotenv

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '0.17.4'
+  spec.add_dependency 'faraday', '< 2'
   spec.add_dependency 'money', '~> 6.13.1'
 
   spec.add_development_dependency 'dotenv'


### PR DESCRIPTION
First I tried to remove the version specification at all but it uses `basic_auth` method here  https://github.com/degica/omni_exchange/blob/ca25a5e96d3969330f0564a659b1c25cbc535bf1/lib/omni_exchange/providers/xe.rb#L25 , which was removed in Faraday 2.0