### PR TITLE
Fixed some bad error handling

### DIFF
--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -34,7 +34,16 @@ module OmniExchange
   end
 
   # if a provider raises one of these exceptions, OmniExchange will gracefully attempt to use another provider
-  EXCEPTIONS = [Faraday::Error, Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError, Net::OpenTimeout, Net::WriteTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError]
+  EXCEPTIONS = [
+    Faraday::Error,
+    Faraday::ConnectionFailed,
+    Faraday::TimeoutError,
+    Faraday::SSLError,
+    Net::OpenTimeout,
+    Net::WriteTimeout,
+    Net::ReadTimeout,
+    OpenSSL::SSL::SSLError
+  ]
 
   module_function
 
@@ -76,12 +85,18 @@ module OmniExchange
 
       exchanged_amount = rate.to_d * amount.to_d
 
-      return { converted_amount: exchanged_amount, exchange_rate: rate, non_subunit_fx_rate: plain_format_rate, provider: OmniExchange::Provider.all.key(klass) }
+      return {
+        converted_amount: exchanged_amount,
+        exchange_rate: rate,
+        non_subunit_fx_rate: plain_format_rate,
+        provider: OmniExchange::Provider.all.key(klass)
+      }
     rescue *EXCEPTIONS, OmniExchange::XeMonthlyLimit, JSON::ParserError => e
       error_messages << e.inspect
     end
 
-    raise OmniExchange::HttpError, "Failed to load #{base_currency}->#{target_currency}:\n#{error_messages.join("\n")}"
+    raise OmniExchange::HttpError, "Failed to load #{base_currency}->#{target_currency}:\n" \
+                                   "#{error_messages.join("\n")}"
   end
 end
 # rubocop:enable Lint/Syntax

--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -80,7 +80,7 @@ module OmniExchange
     rescue *EXCEPTIONS, OmniExchange::XeMonthlyLimit, JSON::ParserError => e
       error_messages << e.inspect
     end
-    
+
     raise OmniExchange::HttpError, "Failed to load #{base_currency}->#{target_currency}:\n#{error_messages.join("\n")}"
   end
 end

--- a/lib/omni_exchange/providers/open_exchange_rates.rb
+++ b/lib/omni_exchange/providers/open_exchange_rates.rb
@@ -21,22 +21,13 @@ module OmniExchange
 
       api = Faraday.new(OmniExchange::OpenExchangeRates::ENDPOINT_URL)
 
-      begin
-        response = api.get do |req|
-          req.url "?app_id=#{app_id}&base=#{base_currency}"
-          req.options.timeout = config[:read_timeout] || OmniExchange::Configuration::DEFAULT_READ_TIMEOUT
-          req.options.open_timeout = config[:connect_timeout] || OmniExchange::Configuration::DEFAULT_CONNECTION_TIMEOUT
-        end
-      rescue *EXCEPTIONS => e
-        raise e.class, 'Open Exchange Rates has timed out.'
+      response = api.get do |req|
+        req.url "?app_id=#{app_id}&base=#{base_currency}"
+        req.options.timeout = config[:read_timeout] || OmniExchange::Configuration::DEFAULT_READ_TIMEOUT
+        req.options.open_timeout = config[:connect_timeout] || OmniExchange::Configuration::DEFAULT_CONNECTION_TIMEOUT
       end
 
-      begin
-        exchange_rate = JSON.parse(response.body, symbolize_names: true)[:rates][target_currency.to_sym].to_d
-      rescue JSON::ParserError => e
-        raise e.class, 'JSON::ParserError in OmniExchange::OpenExchangeRates'
-      end
-
+      exchange_rate = JSON.parse(response.body, symbolize_names: true)[:rates][target_currency.to_sym].to_d
       currency_unit = get_currency_unit(base_currency).to_d
 
       (exchange_rate * currency_unit).to_d

--- a/lib/omni_exchange/providers/xe.rb
+++ b/lib/omni_exchange/providers/xe.rb
@@ -26,21 +26,13 @@ module OmniExchange
         f.adapter :net_http
       end
 
-      begin
-        response = api.get do |req|
-          req.url "v1/convert_from.json/?from=#{base_currency}&to=#{target_currency}&amount=#{currency_unit}"
-          req.options.timeout = config[:read_timeout] || OmniExchange::Configuration::DEFAULT_READ_TIMEOUT
-          req.options.open_timeout = config[:connect_timeout] || OmniExchange::Configuration::DEFAULT_CONNECTION_TIMEOUT
-        end
-      rescue *EXCEPTIONS => e
-        raise e.class, 'xe.com has timed out.'
+      response = api.get do |req|
+        req.url "v1/convert_from.json/?from=#{base_currency}&to=#{target_currency}&amount=#{currency_unit}"
+        req.options.timeout = config[:read_timeout] || OmniExchange::Configuration::DEFAULT_READ_TIMEOUT
+        req.options.open_timeout = config[:connect_timeout] || OmniExchange::Configuration::DEFAULT_CONNECTION_TIMEOUT
       end
 
-      begin
-        body = JSON.parse(response.body, symbolize_names: true)
-      rescue JSON::ParserError => e
-        raise e.class, 'JSON::ParserError in OmniExchange::Xe'
-      end
+      body = JSON.parse(response.body, symbolize_names: true)
 
       raise OmniExchange::XeMonthlyLimit, 'Xe.com monthly limit has been exceeded' if body[:code] == 3
 


### PR DESCRIPTION
I noticed an anti-pattern of rescuing exceptions only to raise different exceptions. This is a bad idea because it hides valuable debugging information from the user.

When this happens, the programmer will find themselves having to remove this code and reproduce the error in order to see what the original exception was.

This is tedious on a dev environment and problematic if it happens on a production environment where we can't just make the error happen again to investigate.

While I was at it, I also added some newlines to make code more readable.