### PR TITLE
Added a way to call the historic rates api with multiple providers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omni_exchange (1.7.0)
+    omni_exchange (1.8.0)
       faraday (< 2)
       money (~> 6.13.1)
 

--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -98,5 +98,23 @@ module OmniExchange
     raise OmniExchange::HttpError, "Failed to load #{base_currency}->#{target_currency}:\n" \
                                    "#{error_messages.join("\n")}"
   end
+
+  def get_historic_rate(base_currency:, target_currencies:, date:, providers:)
+    provider_classes = providers.map { |p| OmniExchange::Provider.load_provider(p) }
+
+    error_messages = []
+
+    provider_classes.each do |klass|
+      return klass.get_historic_rate(base_currency: base_currency,
+                                    target_currencies: target_currencies,
+                                    date: date)
+
+    rescue *EXCEPTIONS, OmniExchange::XeMonthlyLimit, JSON::ParserError => e
+      error_messages << e.inspect
+    end
+
+    raise OmniExchange::HttpError, "Failed to get historic rate:\n" \
+                                   "#{error_messages.join("\n")}"
+  end
 end
 # rubocop:enable Lint/Syntax

--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -99,6 +99,23 @@ module OmniExchange
                                    "#{error_messages.join("\n")}"
   end
 
+  def get_exchange_rate(base_currency:, target_currency:, providers:)
+    provider_classes = providers.map { |p| OmniExchange::Provider.load_provider(p) }
+
+    error_messages = []
+
+    provider_classes.each do |klass|
+      return klass.get_exchange_rate(base_currency: base_currency,
+                                     target_currency: target_currency)
+
+    rescue *EXCEPTIONS, OmniExchange::XeMonthlyLimit, JSON::ParserError => e
+      error_messages << e.inspect
+    end
+
+    raise OmniExchange::HttpError, "Failed to get historic rate:\n" \
+                                   "#{error_messages.join("\n")}"
+  end
+
   def get_historic_rate(base_currency:, target_currencies:, date:, providers:)
     provider_classes = providers.map { |p| OmniExchange::Provider.load_provider(p) }
 

--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -133,6 +133,8 @@ module OmniExchange
   #  ie. "USD", "JPY"
   # @param target_currency: [String] the ISO Currency Code of the currency that you're exchanging to.
   #  ie. "EUR", "KRW"
+  # @param date: [Date] the specific date you want a historic exchange rate for.
+  # ie. Date.new(2018, 12, 25)
   # @param providers: [Array] an array of symbols of the providers that will be used to get exchange rates API
   #   data. The symbols must be found in the @providers hash in the Provider class (lib/omni_exchange/provider.rb).
   #   ie. xe:, :open_exchange_rates

--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -99,6 +99,17 @@ module OmniExchange
                                    "#{error_messages.join("\n")}"
   end
 
+  # returns the latest foreign exchange rate from the base currency to the target currency.
+  #
+  # @param base_currency: [String] the ISO Currency Code of the currency that you're exchanging from.
+  #  ie. "USD", "JPY"
+  # @param target_currency: [String] the ISO Currency Code of the currency that you're exchanging to.
+  #  ie. "EUR", "KRW"
+  # @param providers: [Array] an array of symbols of the providers that will be used to get exchange rates API
+  #   data. The symbols must be found in the @providers hash in the Provider class (lib/omni_exchange/provider.rb).
+  #   ie. xe:, :open_exchange_rates
+  # @ return [BigDecimal] an exchange rate is returned as a BigDecimal for precise calculation since this exchange
+  #   rate will be used to calculate an convert an exchange of currencies.
   def get_exchange_rate(base_currency:, target_currency:, providers:)
     provider_classes = providers.map { |p| OmniExchange::Provider.load_provider(p) }
 
@@ -116,6 +127,17 @@ module OmniExchange
                                    "#{error_messages.join("\n")}"
   end
 
+  # returns the historic exchange rate from the base currency to the target currency at a certain date.
+  #
+  # @param base_currency: [String] the ISO Currency Code of the currency that you're exchanging from.
+  #  ie. "USD", "JPY"
+  # @param target_currency: [String] the ISO Currency Code of the currency that you're exchanging to.
+  #  ie. "EUR", "KRW"
+  # @param providers: [Array] an array of symbols of the providers that will be used to get exchange rates API
+  #   data. The symbols must be found in the @providers hash in the Provider class (lib/omni_exchange/provider.rb).
+  #   ie. xe:, :open_exchange_rates
+  #
+  # @ return [Hash]: A hash containing the exchange rates.
   def get_historic_rate(base_currency:, target_currencies:, date:, providers:)
     provider_classes = providers.map { |p| OmniExchange::Provider.load_provider(p) }
 

--- a/lib/omni_exchange/version.rb
+++ b/lib/omni_exchange/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniExchange
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end

--- a/spec/omni_exchange_spec.rb
+++ b/spec/omni_exchange_spec.rb
@@ -33,6 +33,74 @@ RSpec.describe OmniExchange do
     expect(OmniExchange).not_to be(nil)
   end
 
+  describe '.get_historic_rate' do
+    it 'gets the historic rate for a given date from the first provider' do
+      expect(OmniExchange::OpenExchangeRates).not_to receive(:get_historic_rate)
+      VCR.use_cassette('omni_exchange/xe_historic_rate') do
+        response = OmniExchange.get_historic_rate(date: Date.new(2017, 01, 01),
+                                                  base_currency: 'USD',
+                                                  target_currencies: ['JPY', 'KRW', 'EUR'],
+                                                  providers: [:xe, :open_exchange_rates])
+
+        expect(response.keys).to match_array(['JPY', 'KRW', 'EUR'])
+
+        expect(response['JPY']).to eq(0.1169695e1)
+        expect(response['KRW']).to eq(0.120726e2)
+        expect(response['EUR']).to eq(0.95034e-2)
+      end
+    end
+
+    it 'falls back to the second provider if the first provider fails' do
+      timed_out_xe = double OmniExchange::Xe
+      allow(timed_out_xe).to receive(:get_historic_rate).
+                             and_raise(Faraday::Error, 'slow connection...')
+      allow(OmniExchange::Provider).to receive(:load_provider).
+                                       with(:slow_xe).
+                                       and_return(timed_out_xe)
+      allow(OmniExchange::Provider).to receive(:load_provider).
+                                       with(:open_exchange_rates).
+                                       and_return(OmniExchange::OpenExchangeRates)
+
+      expect(OmniExchange::OpenExchangeRates).to receive(:get_historic_rate).and_call_original
+
+      VCR.use_cassette('omni_exchange/open_exchange_rates_historic_rate') do
+        response = OmniExchange.get_historic_rate(date: Date.new(2017, 01, 01),
+                                                  base_currency: 'USD',
+                                                  target_currencies: ['JPY', 'KRW', 'EUR'],
+                                                  providers: [:slow_xe, :open_exchange_rates])
+
+        expect(response.keys).to match_array(['JPY', 'KRW', 'EUR'])
+
+        expect(response['JPY']).to eq(BigDecimal('0.11682243628e1'))
+        expect(response['KRW']).to eq(BigDecimal('0.120645e2'))
+        expect(response['EUR']).to eq(BigDecimal('0.949713e-2'))
+      end
+    end
+
+    it 'raises an error if all providers fail' do
+      timed_out_xe = double OmniExchange::Xe
+      allow(timed_out_xe).to receive(:get_historic_rate).
+                             and_raise(Faraday::Error, 'slow connection...')
+      allow(OmniExchange::Provider).to receive(:load_provider).
+                                       with(:slow_xe).
+                                       and_return(timed_out_xe)
+
+      failed_oer = double OmniExchange::OpenExchangeRates
+      allow(failed_oer).to receive(:get_historic_rate).
+                           and_raise(Net::ReadTimeout, 'I can not read....')
+      allow(OmniExchange::Provider).to receive(:load_provider).
+                                       with(:failed_oer).
+                                       and_return(failed_oer)
+
+      expect {
+        OmniExchange.get_historic_rate(date: Date.new(2017, 01, 01),
+                                       base_currency: 'USD',
+                                       target_currencies: ['JPY', 'KRW', 'EUR'],
+                                       providers: [:slow_xe, :failed_oer])
+      }.to raise_error(OmniExchange::HttpError)
+    end
+  end
+
   context 'the .get_fx_data' do
     let(:response) do
       VCR.use_cassette('omni_exchange/omni_exchange_get_fx_data', record: :new_episodes) { OmniExchange.get_fx_data(amount: 100, base_currency: 'JPY', target_currency: 'KRW', providers: [:open_exchange_rates]) }

--- a/spec/omni_exchange_spec.rb
+++ b/spec/omni_exchange_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe OmniExchange do
     it 'gets the historic rate for a given date from the first provider' do
       expect(OmniExchange::OpenExchangeRates).not_to receive(:get_historic_rate)
       VCR.use_cassette('omni_exchange/xe_historic_rate') do
-        response = OmniExchange.get_historic_rate(date: Date.new(2017, 01, 01),
+        response = OmniExchange.get_historic_rate(date: Date.new(2017, 0o1, 0o1),
                                                   base_currency: 'USD',
-                                                  target_currencies: ['JPY', 'KRW', 'EUR'],
+                                                  target_currencies: %w[JPY KRW EUR],
                                                   providers: [:xe, :open_exchange_rates])
 
-        expect(response.keys).to match_array(['JPY', 'KRW', 'EUR'])
+        expect(response.keys).to match_array(%w[JPY KRW EUR])
 
         expect(response['JPY']).to eq(0.1169695e1)
         expect(response['KRW']).to eq(0.120726e2)
@@ -52,24 +52,24 @@ RSpec.describe OmniExchange do
 
     it 'falls back to the second provider if the first provider fails' do
       timed_out_xe = double OmniExchange::Xe
-      allow(timed_out_xe).to receive(:get_historic_rate).
-                             and_raise(Faraday::Error, 'slow connection...')
-      allow(OmniExchange::Provider).to receive(:load_provider).
-                                       with(:slow_xe).
-                                       and_return(timed_out_xe)
-      allow(OmniExchange::Provider).to receive(:load_provider).
-                                       with(:open_exchange_rates).
-                                       and_return(OmniExchange::OpenExchangeRates)
+      allow(timed_out_xe).to receive(:get_historic_rate)
+        .and_raise(Faraday::Error, 'slow connection...')
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:slow_xe)
+        .and_return(timed_out_xe)
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:open_exchange_rates)
+        .and_return(OmniExchange::OpenExchangeRates)
 
       expect(OmniExchange::OpenExchangeRates).to receive(:get_historic_rate).and_call_original
 
       VCR.use_cassette('omni_exchange/open_exchange_rates_historic_rate') do
-        response = OmniExchange.get_historic_rate(date: Date.new(2017, 01, 01),
+        response = OmniExchange.get_historic_rate(date: Date.new(2017, 0o1, 0o1),
                                                   base_currency: 'USD',
-                                                  target_currencies: ['JPY', 'KRW', 'EUR'],
+                                                  target_currencies: %w[JPY KRW EUR],
                                                   providers: [:slow_xe, :open_exchange_rates])
 
-        expect(response.keys).to match_array(['JPY', 'KRW', 'EUR'])
+        expect(response.keys).to match_array(%w[JPY KRW EUR])
 
         expect(response['JPY']).to eq(BigDecimal('0.11682243628e1'))
         expect(response['KRW']).to eq(BigDecimal('0.120645e2'))
@@ -79,25 +79,25 @@ RSpec.describe OmniExchange do
 
     it 'raises an error if all providers fail' do
       timed_out_xe = double OmniExchange::Xe
-      allow(timed_out_xe).to receive(:get_historic_rate).
-                             and_raise(Faraday::Error, 'slow connection...')
-      allow(OmniExchange::Provider).to receive(:load_provider).
-                                       with(:slow_xe).
-                                       and_return(timed_out_xe)
+      allow(timed_out_xe).to receive(:get_historic_rate)
+        .and_raise(Faraday::Error, 'slow connection...')
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:slow_xe)
+        .and_return(timed_out_xe)
 
       failed_oer = double OmniExchange::OpenExchangeRates
-      allow(failed_oer).to receive(:get_historic_rate).
-                           and_raise(Net::ReadTimeout, 'I can not read....')
-      allow(OmniExchange::Provider).to receive(:load_provider).
-                                       with(:failed_oer).
-                                       and_return(failed_oer)
+      allow(failed_oer).to receive(:get_historic_rate)
+        .and_raise(Net::ReadTimeout, 'I can not read....')
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:failed_oer)
+        .and_return(failed_oer)
 
-      expect {
-        OmniExchange.get_historic_rate(date: Date.new(2017, 01, 01),
+      expect do
+        OmniExchange.get_historic_rate(date: Date.new(2017, 0o1, 0o1),
                                        base_currency: 'USD',
-                                       target_currencies: ['JPY', 'KRW', 'EUR'],
+                                       target_currencies: %w[JPY KRW EUR],
                                        providers: [:slow_xe, :failed_oer])
-      }.to raise_error(OmniExchange::HttpError)
+      end.to raise_error(OmniExchange::HttpError)
     end
   end
 

--- a/spec/omni_exchange_spec.rb
+++ b/spec/omni_exchange_spec.rb
@@ -33,6 +33,63 @@ RSpec.describe OmniExchange do
     expect(OmniExchange).not_to be(nil)
   end
 
+  describe '.get_exchange_rate' do
+    it 'gets the exchange rate from the first provider' do
+      expect(OmniExchange::OpenExchangeRates).to receive(:get_exchange_rate).and_call_original
+      expect(OmniExchange::Xe).not_to receive(:get_exchange_rate)
+      VCR.use_cassette('omni_exchange/open_exchange_rates_exchange_rate') do
+        response = OmniExchange.get_exchange_rate(base_currency: 'USD',
+                                                  target_currency: 'EUR',
+                                                  providers: [:open_exchange_rates, :xe])
+
+        expect(response).to eq(BigDecimal('0.918119e-2'))
+      end
+    end
+
+    it 'falls back to the second provider if the first provider fails' do
+      timed_out_xe = double OmniExchange::Xe
+      allow(timed_out_xe).to receive(:get_exchange_rate)
+        .and_raise(Faraday::Error, 'slow connection...')
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:slow_xe)
+        .and_return(timed_out_xe)
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:open_exchange_rates)
+        .and_return(OmniExchange::OpenExchangeRates)
+
+      expect(OmniExchange::OpenExchangeRates).to receive(:get_exchange_rate).and_call_original
+      VCR.use_cassette('omni_exchange/open_exchange_rates_exchange_rate') do
+        response = OmniExchange.get_exchange_rate(base_currency: 'USD',
+                                                  target_currency: 'EUR',
+                                                  providers: [:slow_xe, :open_exchange_rates])
+
+        expect(response).to eq(BigDecimal('0.918119e-2'))
+      end
+    end
+
+    it 'raises an error if all providers fail' do
+      timed_out_xe = double OmniExchange::Xe
+      allow(timed_out_xe).to receive(:get_exchange_rate)
+        .and_raise(Faraday::Error, 'slow connection...')
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:slow_xe)
+        .and_return(timed_out_xe)
+
+      failed_oer = double OmniExchange::OpenExchangeRates
+      allow(failed_oer).to receive(:get_exchange_rate)
+        .and_raise(Net::ReadTimeout, 'I can not read this')
+      allow(OmniExchange::Provider).to receive(:load_provider)
+        .with(:failed_oer)
+        .and_return(failed_oer)
+
+      expect do
+        OmniExchange.get_exchange_rate(base_currency: 'USD',
+                                       target_currency: 'EUR',
+                                       providers: [:slow_xe, :failed_oer])
+      end.to raise_error(OmniExchange::HttpError)
+    end
+  end
+
   describe '.get_historic_rate' do
     it 'gets the historic rate for a given date from the first provider' do
       expect(OmniExchange::OpenExchangeRates).not_to receive(:get_historic_rate)

--- a/spec/vcr/omni_exchange/open_exchange_rates_exchange_rate.yml
+++ b/spec/vcr/omni_exchange/open_exchange_rates_exchange_rate.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://openexchangerates.org/api/latest.json?app_id=test&base=USD&symbols=EUR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cache-control:
+      - public
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 09:01:17 GMT
+      etag:
+      - '"22b39fe960f9b1002849bb1254e58abe"'
+      last-modified:
+      - Mon, 26 Jun 2023 09:00:00 GMT
+      server:
+      - nginx/1.12.2
+      content-length:
+      - '217'
+      connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "disclaimer": "Usage subject to terms: https://openexchangerates.org/terms",
+          "license": "https://openexchangerates.org/license",
+          "timestamp": 1687770000,
+          "base": "USD",
+          "rates": {
+            "EUR": 0.918119
+          }
+        }
+  recorded_at: Mon, 26 Jun 2023 09:01:18 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/omni_exchange/open_exchange_rates_historic_rate.yml
+++ b/spec/vcr/omni_exchange/open_exchange_rates_historic_rate.yml
@@ -47,4 +47,51 @@ http_interactions:
           }
         }
   recorded_at: Tue, 06 Jun 2023 09:06:47 GMT
+- request:
+    method: get
+    uri: https://openexchangerates.org/api/historical/2017-01-01.json?app_id=test&base=USD&symbols=JPY%2CKRW%2CEUR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      access-control-allow-origin:
+      - "*"
+      cache-control:
+      - public
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 06:48:21 GMT
+      etag:
+      - '"98dce48bcd2e38dd01ed479b021874e5"'
+      last-modified:
+      - Sun, 01 Jan 2017 23:59:55 GMT
+      server:
+      - nginx/1.12.2
+      content-length:
+      - '262'
+      connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "disclaimer": "Usage subject to terms: https://openexchangerates.org/terms",
+          "license": "https://openexchangerates.org/license",
+          "timestamp": 1483315167,
+          "base": "USD",
+          "rates": {
+            "EUR": 0.949713,
+            "JPY": 116.82243628,
+            "KRW": 1206.45
+          }
+        }
+  recorded_at: Mon, 26 Jun 2023 06:48:21 GMT
 recorded_with: VCR 6.1.0

--- a/spec/vcr/omni_exchange/xe_historic_rate.yml
+++ b/spec/vcr/omni_exchange/xe_historic_rate.yml
@@ -42,4 +42,46 @@ http_interactions:
       encoding: UTF-8
       string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":0.01,"timestamp":"2018-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.0083317565},{"quotecurrency":"JPY","mid":1.1270502279},{"quotecurrency":"KRW","mid":10.6626496918}]}'
   recorded_at: Tue, 06 Jun 2023 06:51:25 GMT
+- request:
+    method: get
+    uri: https://xecdapi.xe.com/v1/historic_rate.json?amount=0.01&date=2017-01-01&from=USD&to=JPY%2CKRW%2CEUR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Mon, 26 Jun 2023 06:27:57 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '271'
+      connection:
+      - keep-alive
+      access-control-allow-origin:
+      - "*"
+      x-ratelimit-limit:
+      - '900'
+      x-ratelimit-remaining:
+      - '899'
+      x-ratelimit-reset:
+      - '1687761000'
+      x-raterequest-limit:
+      - '30000'
+      x-raterequest-remaining:
+      - '28142'
+      x-raterequest-reset:
+      - '1690848000'
+      x-request-id:
+      - 93a82c13-e3f2-4db4-a17e-a7014e5b9642
+    body:
+      encoding: UTF-8
+      string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":0.01,"timestamp":"2017-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.0095034},{"quotecurrency":"JPY","mid":1.169695},{"quotecurrency":"KRW","mid":12.0726}]}'
+  recorded_at: Mon, 26 Jun 2023 06:27:57 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
https://github.com/degica/omni_exchange/pull/6 added a way to query the historic rate for a single provider.

This PR adds a more central method that will query multiple providers similar to the `get_fx_data` method. If the first provider returns an error, it will fall back to the second one and so on.

Edit: I quickly also added a method to get the current exchange rate in a similar way. Until now it wasn't possible to do that without also immediately converting an amount.