### PR TITLE
Return vanilla exchange rates and provider used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omni_exchange (1.8.0)
+    omni_exchange (1.9.0)
       faraday (< 2)
       money (~> 6.13.1)
 
@@ -10,7 +10,7 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     faraday (1.10.3)
@@ -36,7 +36,7 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     money (6.13.8)

--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -116,14 +116,19 @@ module OmniExchange
     error_messages = []
 
     provider_classes.each do |klass|
-      return klass.get_exchange_rate(base_currency: base_currency,
+      rate = klass.get_exchange_rate(base_currency: base_currency,
                                      target_currency: target_currency)
+
+      return {
+        rate: rate,
+        provider: OmniExchange::Provider.all.key(klass)
+      }
 
     rescue *EXCEPTIONS, OmniExchange::XeMonthlyLimit, JSON::ParserError => e
       error_messages << e.inspect
     end
 
-    raise OmniExchange::HttpError, "Failed to get historic rate:\n" \
+    raise OmniExchange::HttpError, "Failed to get exchange rate:\n" \
                                    "#{error_messages.join("\n")}"
   end
 
@@ -146,9 +151,14 @@ module OmniExchange
     error_messages = []
 
     provider_classes.each do |klass|
-      return klass.get_historic_rate(base_currency: base_currency,
-                                    target_currencies: target_currencies,
-                                    date: date)
+      rates = klass.get_historic_rate(base_currency: base_currency,
+                                      target_currencies: target_currencies,
+                                      date: date)
+
+      return {
+        rates: rates,
+        provider: OmniExchange::Provider.all.key(klass)
+      }
 
     rescue *EXCEPTIONS, OmniExchange::XeMonthlyLimit, JSON::ParserError => e
       error_messages << e.inspect

--- a/lib/omni_exchange/providers/open_exchange_rates.rb
+++ b/lib/omni_exchange/providers/open_exchange_rates.rb
@@ -23,10 +23,7 @@ module OmniExchange
           req.params['symbols'] = target_currency
         end
 
-        exchange_rate = body['rates'][target_currency].to_d
-        currency_unit = get_currency_unit(base_currency).to_d
-
-        (exchange_rate * currency_unit).to_d
+        body['rates'][target_currency].to_d
       end
 
       def get_historic_rate(base_currency:, target_currencies:, date:)
@@ -37,10 +34,7 @@ module OmniExchange
           req.params['symbols'] = target_currencies.join(',')
         end
 
-        currency_unit = get_currency_unit(base_currency).to_d
-        body['rates'].transform_values do |rate|
-          (rate * currency_unit).to_d
-        end
+        body['rates']
       end
 
       private

--- a/lib/omni_exchange/providers/xe.rb
+++ b/lib/omni_exchange/providers/xe.rb
@@ -24,7 +24,7 @@ module OmniExchange
 
           req.params['from'] = base_currency
           req.params['to'] = target_currency
-          req.params['amount'] = currency_unit
+          req.params['amount'] = 1
         end
 
         body[:to][0][:mid].to_d

--- a/lib/omni_exchange/providers/xe.rb
+++ b/lib/omni_exchange/providers/xe.rb
@@ -17,8 +17,6 @@ module OmniExchange
       #   rate will be used to calculate an convert an exchange of currencies. However, an exception will be raised
       #   if there is a timeout while connecting to xe.com or a timeout while reading xe.com's API.
       def get_exchange_rate(base_currency:, target_currency:)
-        currency_unit = get_currency_unit(base_currency)
-
         body = api_get do |req|
           req.url 'v1/convert_from.json'
 
@@ -38,14 +36,12 @@ module OmniExchange
       #                                   exchanging to. ie. ["EUR", "KRW"]
       # @param date: [Date] the date for which you want the historic exchange rate.
       def get_historic_rate(base_currency:, target_currencies:, date:)
-        currency_unit = get_currency_unit(base_currency)
-
         body = api_get do |req|
           req.url 'v1/historic_rate.json'
 
           req.params['from'] = base_currency
           req.params['to'] = target_currencies.join(',')
-          req.params['amount'] = currency_unit
+          req.params['amount'] = 1
           req.params['date'] = date.strftime('%Y-%m-%d')
         end
 

--- a/lib/omni_exchange/version.rb
+++ b/lib/omni_exchange/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniExchange
-  VERSION = '1.8.0'
+  VERSION = '1.9.0'
 end

--- a/spec/omni_exchange/providers/open_exchange_rates_spec.rb
+++ b/spec/omni_exchange/providers/open_exchange_rates_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe OmniExchange::OpenExchangeRates do
                                          date: Date.new(2018, 1, 1))
 
         expect(rate).to eq({
-                             'EUR' => BigDecimal('0.832586e-2'),
-                             'JPY' => BigDecimal('0.1127745e1'),
-                             'KRW' => BigDecimal('0.106625e2')
+                             'EUR' => BigDecimal('0.832586'),
+                             'JPY' => BigDecimal('112.7745'),
+                             'KRW' => BigDecimal('1066.25')
                            })
       end
     end

--- a/spec/omni_exchange/providers/xe_spec.rb
+++ b/spec/omni_exchange/providers/xe_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe OmniExchange::Xe do
                                          date: Date.new(2018, 1, 1))
 
         expect(rate).to eq({
-                             'EUR' => BigDecimal('0.83317565e-2'),
-                             'JPY' => BigDecimal('0.11270502279e1'),
-                             'KRW' => BigDecimal('0.106626496918e2')
+                             'EUR' => BigDecimal('0.8331756502'),
+                             'JPY' => BigDecimal('112.7050227918'),
+                             'KRW' => BigDecimal('1066.2649691784')
                            })
       end
     end

--- a/spec/omni_exchange_spec.rb
+++ b/spec/omni_exchange_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe OmniExchange do
         rates = response[:rates]
         expect(rates.keys).to match_array(%w[JPY KRW EUR])
 
-        expect(rates['JPY']).to eq(0.1169695e1)
-        expect(rates['KRW']).to eq(0.120726e2)
-        expect(rates['EUR']).to eq(0.95034e-2)
+        expect(rates['JPY']).to eq(BigDecimal('116.9695'))
+        expect(rates['KRW']).to eq(BigDecimal('1207.26'))
+        expect(rates['EUR']).to eq(BigDecimal('0.95034'))
       end
     end
 

--- a/spec/omni_exchange_spec.rb
+++ b/spec/omni_exchange_spec.rb
@@ -42,7 +42,10 @@ RSpec.describe OmniExchange do
                                                   target_currency: 'EUR',
                                                   providers: [:open_exchange_rates, :xe])
 
-        expect(response).to eq(BigDecimal('0.918119e-2'))
+        expect(response).to eq(
+          provider: :open_exchange_rates,
+          rate: BigDecimal('0.918119')
+        )
       end
     end
 
@@ -63,7 +66,10 @@ RSpec.describe OmniExchange do
                                                   target_currency: 'EUR',
                                                   providers: [:slow_xe, :open_exchange_rates])
 
-        expect(response).to eq(BigDecimal('0.918119e-2'))
+        expect(response).to eq(
+          provider: :open_exchange_rates,
+          rate: BigDecimal('0.918119')
+        )
       end
     end
 
@@ -99,11 +105,14 @@ RSpec.describe OmniExchange do
                                                   target_currencies: %w[JPY KRW EUR],
                                                   providers: [:xe, :open_exchange_rates])
 
-        expect(response.keys).to match_array(%w[JPY KRW EUR])
+        expect(response[:provider]).to eq(:xe)
 
-        expect(response['JPY']).to eq(0.1169695e1)
-        expect(response['KRW']).to eq(0.120726e2)
-        expect(response['EUR']).to eq(0.95034e-2)
+        rates = response[:rates]
+        expect(rates.keys).to match_array(%w[JPY KRW EUR])
+
+        expect(rates['JPY']).to eq(0.1169695e1)
+        expect(rates['KRW']).to eq(0.120726e2)
+        expect(rates['EUR']).to eq(0.95034e-2)
       end
     end
 
@@ -126,11 +135,14 @@ RSpec.describe OmniExchange do
                                                   target_currencies: %w[JPY KRW EUR],
                                                   providers: [:slow_xe, :open_exchange_rates])
 
-        expect(response.keys).to match_array(%w[JPY KRW EUR])
+        expect(response[:provider]).to eq(:open_exchange_rates)
 
-        expect(response['JPY']).to eq(BigDecimal('0.11682243628e1'))
-        expect(response['KRW']).to eq(BigDecimal('0.120645e2'))
-        expect(response['EUR']).to eq(BigDecimal('0.949713e-2'))
+        rates = response[:rates]
+        expect(rates.keys).to match_array(%w[JPY KRW EUR])
+
+        expect(rates['JPY']).to eq(BigDecimal('116.82243628'))
+        expect(rates['KRW']).to eq(BigDecimal('1206.45'))
+        expect(rates['EUR']).to eq(BigDecimal('0.949713'))
       end
     end
 

--- a/spec/vcr/omni_exchange/xe_historic_rate.yml
+++ b/spec/vcr/omni_exchange/xe_historic_rate.yml
@@ -2,49 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://xecdapi.xe.com/v1/historic_rate.json?amount=0.01&date=2018-01-01&from=USD&to=EUR%2CJPY%2CKRW
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v1.10.2
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      date:
-      - Tue, 06 Jun 2023 06:51:24 GMT
-      content-type:
-      - application/json; charset=utf-8
-      content-length:
-      - '284'
-      connection:
-      - keep-alive
-      access-control-allow-origin:
-      - "*"
-      x-ratelimit-limit:
-      - '900'
-      x-ratelimit-remaining:
-      - '899'
-      x-ratelimit-reset:
-      - '1686034800'
-      x-raterequest-limit:
-      - '30000'
-      x-raterequest-remaining:
-      - '21504'
-      x-raterequest-reset:
-      - '1688169600'
-      x-request-id:
-      - 25bb7edb-c26a-49cd-9f5d-220bec0c4e2a
-    body:
-      encoding: UTF-8
-      string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":0.01,"timestamp":"2018-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.0083317565},{"quotecurrency":"JPY","mid":1.1270502279},{"quotecurrency":"KRW","mid":10.6626496918}]}'
-  recorded_at: Tue, 06 Jun 2023 06:51:25 GMT
-- request:
-    method: get
-    uri: https://xecdapi.xe.com/v1/historic_rate.json?amount=0.01&date=2017-01-01&from=USD&to=JPY%2CKRW%2CEUR
+    uri: https://xecdapi.xe.com/v1/historic_rate.json?amount=1&date=2018-01-01&from=USD&to=EUR%2CJPY%2CKRW
     body:
       encoding: US-ASCII
       string: ''
@@ -57,11 +15,11 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Mon, 26 Jun 2023 06:27:57 GMT
+      - Thu, 06 Jul 2023 06:33:11 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '271'
+      - '287'
       connection:
       - keep-alive
       access-control-allow-origin:
@@ -71,17 +29,59 @@ http_interactions:
       x-ratelimit-remaining:
       - '899'
       x-ratelimit-reset:
-      - '1687761000'
+      - '1688625900'
       x-raterequest-limit:
       - '30000'
       x-raterequest-remaining:
-      - '28142'
+      - '24424'
       x-raterequest-reset:
       - '1690848000'
       x-request-id:
-      - 93a82c13-e3f2-4db4-a17e-a7014e5b9642
+      - f3621493-ab17-4f2d-a4d6-7700b7d8631f
     body:
       encoding: UTF-8
-      string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":0.01,"timestamp":"2017-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.0095034},{"quotecurrency":"JPY","mid":1.169695},{"quotecurrency":"KRW","mid":12.0726}]}'
-  recorded_at: Mon, 26 Jun 2023 06:27:57 GMT
+      string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":1.0,"timestamp":"2018-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.8331756502},{"quotecurrency":"JPY","mid":112.7050227918},{"quotecurrency":"KRW","mid":1066.2649691784}]}'
+  recorded_at: Thu, 06 Jul 2023 06:33:11 GMT
+- request:
+    method: get
+    uri: https://xecdapi.xe.com/v1/historic_rate.json?amount=1&date=2017-01-01&from=USD&to=JPY%2CKRW%2CEUR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Thu, 06 Jul 2023 06:54:48 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '268'
+      connection:
+      - keep-alive
+      access-control-allow-origin:
+      - "*"
+      x-ratelimit-limit:
+      - '900'
+      x-ratelimit-remaining:
+      - '899'
+      x-ratelimit-reset:
+      - '1688626800'
+      x-raterequest-limit:
+      - '30000'
+      x-raterequest-remaining:
+      - '24419'
+      x-raterequest-reset:
+      - '1690848000'
+      x-request-id:
+      - 72c0b1bf-8c64-4b57-b286-b8c94b399505
+    body:
+      encoding: UTF-8
+      string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":1.0,"timestamp":"2017-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.95034},{"quotecurrency":"JPY","mid":116.9695},{"quotecurrency":"KRW","mid":1207.26}]}'
+  recorded_at: Thu, 06 Jul 2023 06:54:48 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
Made some changes to to the API routes to fetch latest/historic exchange rates.

* They now also return information about which provider was used.
* They return the exchange rate as is instead of multiplying it by the currency unit.

The latter means that the old code would provide exchange rates that expected you to use cents in your conversions. For example when converting $1 to JPY, you'd have to `100 * exchange rate`. 100 cents instead of 1 dollar. Figured this isn't intuitive so I got rid of it.

Now it just returns the actual exchange rate so converting $1 to JPY becomes `1 * exchange_rate`