### PR TITLE
Update xe temporary url

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0.1', '3.1.1', '3.2.1', '3.3.1', '3.4.1']
+        ruby-version: ['3.1.1', '3.2.1', '3.3.1', '3.4.1']
       fail-fast: false
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+        bundler: '2.5.23'
     - name: Install dependencies
       run: bundle install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,24 @@
-name: Ruby
+name: Ruby Tests
 
-on: [push,pull_request]
+on: [push, pull_request]
 
 jobs:
-  build:
+  test:
+    name: Ruby ${{ matrix.ruby-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
-
+        ruby-version: ['3.0.1', '3.1.1', '3.2.1', '3.3.1', '3.4.1']
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Run the default task
-      run: |
-        bundle install
-        bundle exec rake
+        bundler-cache: true
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.3
+        ruby-version: 3.4.1
     - name: Run the default task
       run: |
-        gem install bundler -v 2.2.3
         bundle install
         bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,16 @@ on: [push,pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby
+    - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.4.1
+        ruby-version: ${{ matrix.ruby-version }}
     - name: Run the default task
       run: |
         bundle install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2025-01-30
+## [3.0.0] - 2025-01-31
 
 ### Changed
 
-- Updated XE endpoint_url as per their recommendation.
+- Updated XE endpoint_url to use an alternative one as per their recommendation.
+- Added dependencies and updated requires that were using ruby's standard library no longer supported since Ruby 3.0.0
+- Updated workflow to account for different ruby versions.
+- Updated minimum required ruby version as per the newly added workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated XE endpoint_url to use an alternative one as per their recommendation.
 - Added dependencies and updated requires that were using ruby's standard library no longer supported since Ruby 3.0.0
-- Updated workflow to account for different ruby versions.
-- Updated minimum required ruby version as per the newly added workflow.
+- Supports Ruby versions 3.1, 3.2, 3.3, and 3.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.0] - 2025-01-28
+
+### Changed
+
+- Updated XE endpoint_url as per their recommendation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2025-01-28
+## [2.1.0] - 2025-01-30
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omni_exchange (2.1.0)
-      faraday (~> 2.12)
+      faraday (~> 2)
       money (~> 6.13.1)
 
 GEM
@@ -81,4 +81,4 @@ DEPENDENCIES
   vcr
 
 BUNDLED WITH
-   2.3.9
+   2.6.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,18 @@ PATH
   remote: .
   specs:
     omni_exchange (2.1.0)
+      base64 (~> 0.2.0)
       bigdecimal (~> 3)
       faraday (~> 2)
       money (~> 6.13.1)
-      stringio (~> 3.1)
+      racc (~> 1.4)
+      stringio (~> 3.1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    base64 (0.2.0)
     bigdecimal (3.1.9)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
@@ -37,6 +40,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (12.3.3)
     regexp_parser (2.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omni_exchange (2.1.0)
-      faraday (~> 2)
+      faraday (~> 2.12)
       money (~> 6.13.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,16 @@ PATH
   remote: .
   specs:
     omni_exchange (2.1.0)
+      bigdecimal (~> 3)
       faraday (~> 2)
       money (~> 6.13.1)
+      stringio (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bigdecimal (3.1.9)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     diff-lcs (1.5.0)
@@ -63,6 +66,7 @@ GEM
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    stringio (3.1.2)
     unicode-display_width (1.8.0)
     uri (1.0.2)
     vcr (6.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omni_exchange (2.0.0)
+    omni_exchange (2.1.0)
       faraday (~> 2)
       money (~> 6.13.1)
 
@@ -10,19 +10,23 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.5)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
-    faraday-net_http (3.1.0)
-      net-http
-    i18n (1.14.4)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    json (2.9.1)
+    logger (1.6.5)
     method_source (1.0.0)
     money (6.13.8)
       i18n (>= 0.6.4, <= 2)
-    net-http (0.4.1)
+    net-http (0.6.0)
       uri
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -60,7 +64,7 @@ GEM
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (1.8.0)
-    uri (0.13.0)
+    uri (1.0.2)
     vcr (6.1.0)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omni_exchange (2.1.0)
+    omni_exchange (3.0.0)
       base64 (~> 0.2.0)
       bigdecimal (~> 3)
       faraday (~> 2)

--- a/lib/omni_exchange.rb
+++ b/lib/omni_exchange.rb
@@ -2,7 +2,7 @@
 
 require 'omni_exchange/provider'
 # in order to make sure that all API data providers are registered correctly,
-#   all of the provider files in the providers folder must be required
+# all of the provider files in the providers folder must be required
 require 'omni_exchange/providers/open_exchange_rates'
 require 'omni_exchange/providers/xe'
 require 'omni_exchange/version'
@@ -11,7 +11,7 @@ require 'omni_exchange/error'
 require 'faraday'
 require 'money'
 require 'json'
-require 'bigdecimal/util'
+require 'bigdecimal'
 require 'net/http'
 
 # rubocop:disable Lint/Syntax

--- a/lib/omni_exchange/providers/xe.rb
+++ b/lib/omni_exchange/providers/xe.rb
@@ -4,7 +4,7 @@ require 'omni_exchange'
 
 module OmniExchange
   class Xe < Provider
-    ENDPOINT_URL = 'https://xecdapi.xe.com/'
+    ENDPOINT_URL = 'https://xecd-api-ssl.xe.com/'
 
     class << self
       # This method returns the exchange rate, the rate at which the smallest unit of one currency (the base currency)

--- a/lib/omni_exchange/version.rb
+++ b/lib/omni_exchange/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniExchange
-  VERSION = '2.1.0'
+  VERSION = '3.0.0'
 end

--- a/lib/omni_exchange/version.rb
+++ b/lib/omni_exchange/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniExchange
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 2'
+  spec.add_dependency 'faraday', '~> 2.12'
   spec.add_dependency 'money', '~> 6.13.1'
 
   spec.add_development_dependency 'dotenv'

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'OmniExchange converts currencies using up-to-the-minute foreign exchange rates.'
   spec.homepage      = 'https://degica.com'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 2'
   spec.add_dependency 'money', '~> 6.13.1'
+  spec.add_dependency 'bigdecimal', '~> 3'
+  spec.add_dependency 'stringio', '~> 3.1'
 
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'pry'

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -2,6 +2,7 @@
 
 require_relative 'lib/omni_exchange/version'
 
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
   spec.name          = 'omni_exchange'
   spec.version       = OmniExchange::VERSION
@@ -30,7 +31,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 2'
   spec.add_dependency 'money', '~> 6.13.1'
   spec.add_dependency 'bigdecimal', '~> 3'
-  spec.add_dependency 'stringio', '~> 3.1'
+  spec.add_dependency 'stringio', '~> 3.1.2'
+  spec.add_dependency 'racc', '~> 1.4'
+  spec.add_dependency 'base64', '~> 0.2.0'
 
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'pry'
@@ -39,3 +42,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.80'
   spec.add_development_dependency 'vcr'
 end
+# rubocop:enable Metrics/BlockLength

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -28,12 +28,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'base64', '~> 0.2.0'
+  spec.add_dependency 'bigdecimal', '~> 3'
   spec.add_dependency 'faraday', '~> 2'
   spec.add_dependency 'money', '~> 6.13.1'
-  spec.add_dependency 'bigdecimal', '~> 3'
-  spec.add_dependency 'stringio', '~> 3.1.2'
   spec.add_dependency 'racc', '~> 1.4'
-  spec.add_dependency 'base64', '~> 0.2.0'
+  spec.add_dependency 'stringio', '~> 3.1.2'
 
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'pry'

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'OmniExchange converts currencies using up-to-the-minute foreign exchange rates.'
   spec.homepage      = 'https://degica.com'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.1')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 2.12'
+  spec.add_dependency 'faraday', '~> 2'
   spec.add_dependency 'money', '~> 6.13.1'
 
   spec.add_development_dependency 'dotenv'

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'OmniExchange converts currencies using up-to-the-minute foreign exchange rates.'
   spec.homepage      = 'https://degica.com'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.1')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 

--- a/spec/omni_exchange/providers/xe_spec.rb
+++ b/spec/omni_exchange/providers/xe_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe OmniExchange::Xe do
       VCR.use_cassette('omni_exchange/xe_historic_rate') do
         rate = subject.get_historic_rate(base_currency: 'USD',
                                          target_currencies: %w[EUR JPY KRW],
-                                         date: Date.new(2018, 1, 1))
+                                         date: Date.new(2017, 1, 1))
 
         expect(rate).to eq({
                              'EUR' => BigDecimal('0.8331756502'),

--- a/spec/omni_exchange/providers/xe_spec.rb
+++ b/spec/omni_exchange/providers/xe_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe OmniExchange::Xe do
     it 'returns the exchange rates from the date specified' do
       VCR.use_cassette('omni_exchange/xe_historic_rate') do
         rate = subject.get_historic_rate(base_currency: 'USD',
-                                         target_currencies: %w[EUR JPY KRW],
+                                         target_currencies: %w[JPY KRW EUR],
                                          date: Date.new(2017, 1, 1))
 
         expect(rate).to eq({
-                             'EUR' => BigDecimal('0.8331756502'),
-                             'JPY' => BigDecimal('112.7050227918'),
-                             'KRW' => BigDecimal('1066.2649691784')
+                             'EUR' => BigDecimal('0.95034'),
+                             'JPY' => BigDecimal('116.9695'),
+                             'KRW' => BigDecimal('1207.26')
                            })
       end
     end

--- a/spec/vcr/omni_exchange/xe_historic_rate.yml
+++ b/spec/vcr/omni_exchange/xe_historic_rate.yml
@@ -7,8 +7,6 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Authorization:
-      - Basic ZGVnaWNhY28uLGx0ZC43MzM5MjYyNDQ6bzhzMWtyZjkyZDA3Mm83Ymw2aG1qMGZqdmE=
       User-Agent:
       - Faraday v2.12.2
   response:

--- a/spec/vcr/omni_exchange/xe_historic_rate.yml
+++ b/spec/vcr/omni_exchange/xe_historic_rate.yml
@@ -2,24 +2,26 @@
 http_interactions:
 - request:
     method: get
-    uri: https://xecdapi.xe.com/v1/historic_rate.json?amount=1&date=2018-01-01&from=USD&to=EUR%2CJPY%2CKRW
+    uri: https://xecd-api-ssl.xe.com/v1/historic_rate.json?amount=1&date=2017-01-01&from=USD&to=JPY%2CKRW%2CEUR
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Authorization:
+      - Basic ZGVnaWNhY28uLGx0ZC43MzM5MjYyNDQ6bzhzMWtyZjkyZDA3Mm83Ymw2aG1qMGZqdmE=
       User-Agent:
-      - Faraday v1.10.3
+      - Faraday v2.12.2
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Thu, 06 Jul 2023 06:33:11 GMT
+      - Thu, 30 Jan 2025 06:33:36 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '287'
+      - '262'
       connection:
       - keep-alive
       access-control-allow-origin:
@@ -29,59 +31,17 @@ http_interactions:
       x-ratelimit-remaining:
       - '899'
       x-ratelimit-reset:
-      - '1688625900'
+      - '1738219500'
       x-raterequest-limit:
       - '30000'
       x-raterequest-remaining:
-      - '24424'
+      - '29962'
       x-raterequest-reset:
-      - '1690848000'
+      - '1740787200'
       x-request-id:
-      - f3621493-ab17-4f2d-a4d6-7700b7d8631f
+      - 54293ed7-5a2a-4ca4-92f1-4fb55ce155e9
     body:
       encoding: UTF-8
-      string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":1.0,"timestamp":"2018-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.8331756502},{"quotecurrency":"JPY","mid":112.7050227918},{"quotecurrency":"KRW","mid":1066.2649691784}]}'
-  recorded_at: Thu, 06 Jul 2023 06:33:11 GMT
-- request:
-    method: get
-    uri: https://xecdapi.xe.com/v1/historic_rate.json?amount=1&date=2017-01-01&from=USD&to=JPY%2CKRW%2CEUR
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v1.10.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      date:
-      - Thu, 06 Jul 2023 06:54:48 GMT
-      content-type:
-      - application/json; charset=utf-8
-      content-length:
-      - '268'
-      connection:
-      - keep-alive
-      access-control-allow-origin:
-      - "*"
-      x-ratelimit-limit:
-      - '900'
-      x-ratelimit-remaining:
-      - '899'
-      x-ratelimit-reset:
-      - '1688626800'
-      x-raterequest-limit:
-      - '30000'
-      x-raterequest-remaining:
-      - '24419'
-      x-raterequest-reset:
-      - '1690848000'
-      x-request-id:
-      - 72c0b1bf-8c64-4b57-b286-b8c94b399505
-    body:
-      encoding: UTF-8
-      string: '{"terms":"http://www.xe.com/legal/dfs.php","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":1.0,"timestamp":"2017-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.95034},{"quotecurrency":"JPY","mid":116.9695},{"quotecurrency":"KRW","mid":1207.26}]}'
-  recorded_at: Thu, 06 Jul 2023 06:54:48 GMT
+      string: '{"terms":"https://www.xe.com/legal/","privacy":"http://www.xe.com/privacy.php","from":"USD","amount":1.0,"timestamp":"2017-01-01T00:00:00Z","to":[{"quotecurrency":"EUR","mid":0.95034},{"quotecurrency":"JPY","mid":116.9695},{"quotecurrency":"KRW","mid":1207.26}]}'
+  recorded_at: Thu, 30 Jan 2025 06:33:36 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
~~TODO:~~
~~Add testing instructions~~

Tackles: https://degica.atlassian.net/jira/software/projects/CO/boards/30?selectedIssue=CO-571

## How to test
1. If you haven't already done so, please fork the omni_exchange repo and run `bundle install`.
2. Run `bin/console`.
3. Set up some auth configurations for `XE.com`. You'll find the `XE.com` Account API ID and Account API key in the cash-out team vault in 1Password:
```bash
OmniExchange.configure do |config|
  config.provider_config = {
    xe: {
      api_id: 'your XE account API ID goes here as a string', # REQUIRED TO USE XE.com
      api_key: 'your XE account API key goes here as a string', # REQUIRED TO USE XE.com
    }
  }
end
```

4. If everything is set up correctly, you should be able to get foreign exchange data for 1 USD (note: this is 1 dollar, not 1 cent) to JPY:
```bash
USD_to_JPY = OmniExchange.get_fx_data(amount: 1, base_currency: 'USD', target_currency: 'JPY', providers: [:xe])
```

5. Run `USD_to_JPY[:converted_amount].to_f`. You should get back something around 155.2554851133 (which means 1 USD equals around 155 JPY).
