### PR TITLE
Update organization name after repo transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and issues are welcome on GitHub at https://github.com/komoju/omni\_exchange. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/komoju/omni_exchange/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and issues are welcome on GitHub at https://github.com/komoju/omni_exchange. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/komoju/omni_exchange/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and issues are welcome on GitHub at https://github.com/degica/omni_exchange. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/degica/omni_exchange/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and issues are welcome on GitHub at https://github.com/komoju/omni\_exchange. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/komoju/omni_exchange/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -98,4 +98,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the OmniExchange project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/degica/omni_exchange/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the OmniExchange project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/komoju/omni_exchange/blob/master/CODE_OF_CONDUCT.md).

--- a/omni_exchange.gemspec
+++ b/omni_exchange.gemspec
@@ -11,15 +11,15 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'OmniExchange converts currencies using up-to-the-minute foreign exchange rates.'
   spec.description   = 'OmniExchange converts currencies using up-to-the-minute foreign exchange rates.'
-  spec.homepage      = 'https://degica.com'
+  spec.homepage      = 'https://komoju.com'
   spec.license       = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.1')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  spec.metadata['homepage_uri'] = 'https://degica.com'
-  spec.metadata['source_code_uri'] = 'https://github.com/degica/omni_exchange'
-  spec.metadata['changelog_uri'] = 'https://github.com/degica/omni_exchange'
+  spec.metadata['homepage_uri'] = 'https://komoju.com'
+  spec.metadata['source_code_uri'] = 'https://github.com/komoju/omni_exchange'
+  spec.metadata['changelog_uri'] = 'https://github.com/komoju/omni_exchange'
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }


### PR DESCRIPTION
This PR updates links to reflect the current location of the repository after the code has been transferred to KOMOJU organization.